### PR TITLE
Updating docker-compose.yml and .env files

### DIFF
--- a/deploy/opal_poll/.env
+++ b/deploy/opal_poll/.env
@@ -11,7 +11,7 @@ QP_DATA_DIR=/opt/dsqp
 OPAL_ADMIN_PASS=password 
 R_SERVER_HOST=datashield_rserver
 OPAL_MONGODB_HOST=datashield_mongo
-DS_VERSION=6.0.0
+DS_VERSION=6.2.2
 DS_PRIVACY_LEVEL=5
 
 # e.g. 123.12.12.12:443 , queue server host and port(usually 443)

--- a/deploy/opal_poll/docker-compose.yml
+++ b/deploy/opal_poll/docker-compose.yml
@@ -4,29 +4,41 @@ services:
   opal:
     container_name: datashield_opal
     restart: unless-stopped
-    image: docker.miracum.org/datashield_miracum/ds_opal:v0.10.1
+    image: docker.miracum.org/datashield_miracum/ds_opal:v0.12.1
     ports:
       - "443:8443"
     networks:
       - opal_net
     environment:
       - OPAL_ADMINISTRATOR_PASSWORD=${OPAL_ADMIN_PASS}
-      - RSERVER_PORT_6312_TCP_ADDR=${R_SERVER_HOST}
       - MONGODBHOST=${OPAL_MONGODB_HOST}
       - INITTESTDATA=true
-      - DS_VERSION=${DS_VERSION:-6.0.0}
+      - DS_VERSION=${DS_VERSION:-6.2.2}
       - DS_PRIVACY_LEVEL=$DS_PRIVACY_LEVEL
+      - ROCK_HOSTS=rock1:8085,rock2:8085
     volumes:
       - ${QP_DATA_DIR}/opal:/srv
       - /etc/dsqp/auth:/auth
       - /etc/dsqp/miracum_users:/miracum_users
 
-  rserver:
-    container_name: datashield_rserver
+  rock1:
     restart: unless-stopped
-    image: obiba/opal-rserver:1.6
+    image: datashield/rock-base:6.2
+    environment:
+      - ROCK_ID=default-1
+      - ROCK_CLUSTER=default
     networks:
       - opal_net
+
+  rock2:
+    image: datashield/rock-base:6.2
+    restart: unless-stopped
+    environment:
+      - ROCK_ID=default-2
+      - ROCK_CLUSTER=default
+    networks:
+      - opal_net
+
 
   mongo:
     container_name: datashield_mongo


### PR DESCRIPTION
A new docker image of ds_opal (OPAL Version 4.2) has been created and publised unter MIRACUM Harbor (docker.miracum.org/datashield_miracum/ds_opal:v0.12.1). The docker-deployment with the current version of docker-compose.yml and .env has been successfully testet.